### PR TITLE
Docker image fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build-image:
 	$(AT)$(DOCKER) rm $(BOOT_CONTAINER)
 
 run-image:
-	$(AT)$(DOCKER) run -it $(DOCKER_RUN_OPTIONS) --rm localhost/$(IMAGE_NAME) || echo -e "\n\nPlease run make build-image first"
+	$(AT)$(DOCKER) run -it $(DOCKER_RUN_OPTIONS) --rm $(IMAGE_NAME) || echo -e "\n\nPlease run make build-image first"
 
 refresh-image:
 	$(AT)$(DOCKER) run --name=$(BOOT_CONTAINER) -itd $(IMAGE_NAME)


### PR DESCRIPTION
Fix error:

```
$ make run-image
Unable to find image 'localhost/mandrel-packaging:latest' locally
docker: Error response from daemon: Get http://localhost/v2/: dial tcp [::1]:80: connect: connection refused.
See 'docker run --help'.
-e

Please run make build-image first
```